### PR TITLE
Fixing Broken Page

### DIFF
--- a/book-service/src/main/java/com/cs4015/bookstore/bookservice/bean/BuyBookMB.java
+++ b/book-service/src/main/java/com/cs4015/bookstore/bookservice/bean/BuyBookMB.java
@@ -28,7 +28,7 @@ public class BuyBookMB {
 	private String author;
 	private Double minPrice;
 	private Double maxPrice;
-	private String bookType;
+	private BookType bookType;
 
 	@Autowired
 	public BuyBookMB(@Qualifier("mockService") BookService bookService) {
@@ -80,7 +80,7 @@ public class BuyBookMB {
 				isMatch = false;
 			}
 
-			if (bookType != null && book.getBookType() != bookType) {
+			if (bookType != null && !book.getBookType().equals(bookType.name())) {
 				isMatch = false;
 			}
 

--- a/book-service/src/main/webapp/textbook-buy-form.xhtml
+++ b/book-service/src/main/webapp/textbook-buy-form.xhtml
@@ -62,15 +62,15 @@
                                     <p:row>
                                         <b>Book Format</b>
                                         <p>
-                                            #{book.bookType.name()}
+                                            #{book.bookType}
                                             <i>
                                                 (
                                                 <ui:fragment rendered="#{book.bookType != enumValuesProvider.digitalBookType()}">
-                                                    #{book.condition.name()}
+                                                    #{book.condition}
                                                 </ui:fragment>
 
                                                 <ui:fragment rendered="#{book.bookType == enumValuesProvider.digitalBookType()}">
-                                                    #{book.digitalFormat.name()}
+                                                    #{book.digitalFormat}
                                                 </ui:fragment>
                                                 )
                                             </i>


### PR DESCRIPTION
Error was caused by changing the type of `Book.bookType` from `enum` to `String`.