### PR TITLE
Handling Unique Username Error

### DIFF
--- a/book-service/src/main/java/com/cs4015/bookstore/bookservice/bean/SignupMB.java
+++ b/book-service/src/main/java/com/cs4015/bookstore/bookservice/bean/SignupMB.java
@@ -5,12 +5,11 @@ import javax.enterprise.context.RequestScoped;
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
 
-import com.cs4015.bookstore.api.core.book.services.BookService;
 import com.cs4015.bookstore.bookservice.core.user.model.User;
 import com.cs4015.bookstore.bookservice.core.user.services.UserService;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 import lombok.Data;
@@ -31,9 +30,13 @@ public class SignupMB {
 	}
 
 	public void createUser() {
-		User saveUser = bookService.saveUser(user);
-		if (saveUser.getUserId() > 0) {
+		try {
+			bookService.saveUser(user);
 			FacesContext.getCurrentInstance().addMessage("messages", new FacesMessage("User created successfully."));
+		} catch (DataIntegrityViolationException e) {
+			FacesContext.getCurrentInstance().addMessage("messages", new FacesMessage(FacesMessage.SEVERITY_ERROR, "There is already a user with this username.", ""));
+		} catch (Exception e) {
+			FacesContext.getCurrentInstance().addMessage("messages", new FacesMessage(FacesMessage.SEVERITY_ERROR, "Failed to create user.", e.getMessage()));
 		}
 	}
 }


### PR DESCRIPTION
Instead of throwing an error when a new username already exists in the DB, show a message to the user.